### PR TITLE
Fix: (queued players) message placeholder

### DIFF
--- a/src/adapter/discord/discord-publisher.ts
+++ b/src/adapter/discord/discord-publisher.ts
@@ -85,13 +85,15 @@ export class DiscordPublisher implements GameStatusPublisher {
             let message = this.formats.playerCount
                 .replace('${playerCount}', status.playerCount.toString())
                 .replace('${maxPlayers}', status.maxPlayers.toString());
-            if (status.queuedPlayers) {
+            if (status.queuedPlayers && message.indexOf('${queuedPlayersMessage}') !== -1) {
                 message = message.replace(
                     '${queuedPlayersMessage}',
                     this.formats.queuedPlayers.replace('${queuedPlayers}', status.queuedPlayers.toString(10))
                 );
             } else {
-                message = message.replace('${queuedPlayersMessage}', '');
+                message = message
+                  .replace('${queuedPlayersMessage}', '')
+                  .replace('${queuedPlayers}', '');
             }
             this.client.user?.setPresence({
                 status: 'online',

--- a/src/adapter/discord/discord-publisher.ts
+++ b/src/adapter/discord/discord-publisher.ts
@@ -85,11 +85,19 @@ export class DiscordPublisher implements GameStatusPublisher {
             let message = this.formats.playerCount
                 .replace('${playerCount}', status.playerCount.toString())
                 .replace('${maxPlayers}', status.maxPlayers.toString());
-            if (status.queuedPlayers && message.indexOf('${queuedPlayersMessage}') !== -1) {
-                message = message.replace(
+            if (status.queuedPlayers) {
+                if (message.indexOf('${queuedPlayersMessage}') !== -1) {
+                  message = message.replace(
                     '${queuedPlayersMessage}',
                     this.formats.queuedPlayers.replace('${queuedPlayers}', status.queuedPlayers.toString(10))
-                );
+                  );
+                }
+                if (message.indexOf('${queuedPlayers}') !== -1) {
+                  message = message.replace(
+                    '${queuedPlayers}',
+                    status.queuedPlayers.toString(10)
+                  );
+                }
             } else {
                 message = message
                   .replace('${queuedPlayersMessage}', '')

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ class App {
         this.client = await this.createDiscordClient();
         try {
             const publisher = new DiscordPublisher(this.client, new FileBackedMapRepository(), {
-                playerCount: process.env.DISCORD_PUBLISHER_MESSAGE_FORMAT || '${playerCount}/${maxPlayers} $queuedPlayers',
+                playerCount: process.env.DISCORD_PUBLISHER_MESSAGE_FORMAT || '${playerCount}/${maxPlayers} $queuedPlayersMessage',
                 queuedPlayers: process.env.DISCORD_PUBLISHER_MESSAGE_QUEUED_FORMAT || '(+${queuedPlayers})',
             });
             this.useCase = new ProvideGameStatus(providerFactory().build(), publisher);


### PR DESCRIPTION
- Fixes #16
- Default `playerCount` format now uses `$queuedPlayersMessage` instead of `$queuedPlayers`
- `$queuedPlayers` is now parsed standalone, even if `$queuedPlayersMessage` is not used
- Placeholders/tags are removed from output if `queued` players is not resolved or implemented by provider
- Closes #18, which is not a fix for the aforementioned issue

Ignore the "fixes #123" in the commit body 🙈 