### PR TITLE
build: optimize docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,10 @@
+assets/
+maps-examples/
 node_modules/
+
+.dockerignore
+docker-compose.yml
+Dockerfile
+example.env
+Procfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
-FROM node:20-alpine as build
-
-WORKDIR /code
-RUN apk add --no-cache git
+# Stage 1: Build
+FROM node:24-alpine AS build
+WORKDIR /usr/src/build
+COPY package.json package-lock.json ./
+RUN npm ci
 COPY . .
-RUN npm ci && npm run build
+RUN npm run build
 
-FROM node:20-alpine
-
-WORKDIR /app
-RUN apk add --no-cache --virtual build-dependencies git
-COPY package.json .
-RUN npm install --only=production
-RUN apk del build-dependencies
-COPY --from=build /code/dist/ .
-
-CMD ["node", "/app/index.js"]
+# Stage 2: Production/Runtime
+FROM node:24-alpine AS production
+WORKDIR /usr/src/app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+COPY --from=build /usr/src/build/dist ./dist
+CMD ["node", "/usr/src/app/index.js"]

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     }
   },
   "engines": {
-    "node": "20.x.x"
+    "node": ">=20"
   },
   "optionalDependencies": {
     "fsevents": "*"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     }
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=20 <=24"
   },
   "optionalDependencies": {
     "fsevents": "*"


### PR DESCRIPTION
- Minimized build artifacts by updating .dockerignore
- Standalone npm dependency caching layer (code changes don't trigger a reinstall anymore, only updates to `package*.json` files)
- Local `env` files don't need to be included in `.dockerignore`, as they are already ignored in the build because it's defined in `.gitignore` - could add it for completeness though!
- For this codebase, `<=node24` is fully backwards compatible going back to `node20`
  
I am really not sure why `build-dependencies` and `git` were used in the Docker build, I really couldn't find a reason why these would be needed, compiled the new image using `--no-cache` without any issue. Do let me know if I should add this back in, and if so, why it is required.